### PR TITLE
Fix FAKE Chinese text bug

### DIFF
--- a/src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs
+++ b/src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs
@@ -1180,7 +1180,7 @@ module internal Helper =
     override __.Dispose (r) =
       base.Dispose r
       if r then doAll (fun t -> t.Dispose())
-    override __.Encoding = l.Head.Encoding
+    override __.Encoding = Encoding.UTF8
     static member Create l = new CombineTextWriter (l) :> TextWriter
   type OutStreamHelper (saveGlobal, liveOutWriter : _ option, liveFsiWriter : _ option) =
     let globalFsiOut = new StringBuilder()


### PR DESCRIPTION
See
https://github.com/fsharp/FAKE/issues/1196,
https://github.com/fsharp/FAKE/pull/1212,
https://github.com/fsharp/FAKE/pull/1213 &
https://github.com/fsharp/FAKE/pull/1194

Not sure of the ramifications of this change, but this fixes the
encoding issues in FAKE on Mono for me.

l.Head.Encoding was
`System.IO.StringWriter(new System.Text.StringBuilder()).Encoding`
which evaluates to utf-16 on both Windows and on Mono
/cc:@forki