### PR TITLE
FSharpAssemblyHelper -> FSharpCheckerFuncs

### DIFF
--- a/src/test/Test.Yaaf.FSharp.Scripting/ExtensionMethodTests.fs
+++ b/src/test/Test.Yaaf.FSharp.Scripting/ExtensionMethodTests.fs
@@ -41,13 +41,13 @@ let testType<'a> () =
 
 [<Test>]
 let ``check that default assemblies generate no warnings`` () =
-    let frameworkVersion = FSharpAssemblyHelper.defaultFrameworkVersion
-    let sysLibs = FSharpAssemblyHelper.getDefaultSystemReferences frameworkVersion
-    let fsCore = FSharpAssemblyHelper.findFSCore [] []
+    let frameworkVersion = FSharpCheckerFuncs.defaultFrameworkVersion
+    let sysLibs = FSharpCheckerFuncs.getDefaultSystemReferences frameworkVersion
+    let fsCore = FSharpCheckerFuncs.findFSCore [] []
     //for sysLib in sysLibs do
-    let projFileName, args = FSharpAssemblyHelper.getCheckerArguments frameworkVersion sysLibs (Some fsCore) [] [] []
-    let options = FSharpAssemblyHelper.checker.GetProjectOptionsFromCommandLineArgs(projFileName, args)
-    let results = FSharpAssemblyHelper.checker.ParseAndCheckProject(options) |> Async.RunSynchronously
+    let projFileName, args = FSharpCheckerFuncs.getCheckerArguments frameworkVersion sysLibs (Some fsCore) [] [] []
+    let options = FSharpCheckerFuncs.checker.GetProjectOptionsFromCommandLineArgs(projFileName, args)
+    let results = FSharpCheckerFuncs.checker.ParseAndCheckProject(options) |> Async.RunSynchronously
     test <@ results.Errors.Length = 0 @>
 
 [<Test>]


### PR DESCRIPTION
I noticed that the test doesn't compile due to the module having changed name 